### PR TITLE
Concepts

### DIFF
--- a/.github/matrix/concept.yaml
+++ b/.github/matrix/concept.yaml
@@ -1,0 +1,27 @@
+---
+matrix:
+  pkg:
+    - name: Example
+      repo: https://github.com/JuliaLang/Example.jl
+  version:
+    - "1.6"
+    - "1"
+  os:
+    - ubuntu-latest
+    - macos-latest-large
+    - macos-latest-xlarge  # Apple silicon: https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+  arch:
+    - x86
+    - x64
+    - aarch64
+  exclude:
+    - os: ubuntu-latest
+      arch: aarch64
+    - os: macos-latest-large
+      arch: x86
+    - os: macos-latest-large
+      arch: aarch64
+    - os: macos-latest-xlarge
+      arch: x86
+    - os: macos-latest-xlarge
+      arch: x64

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   check-dist:
-    name: Check dist/
+    name: Check dist
     runs-on: ubuntu-latest
 
     steps:
@@ -39,7 +39,7 @@ jobs:
         id: install
         run: npm ci
 
-      - name: Build dist/ Directory
+      - name: Build dist Directory
         id: build
         run: npm run bundle
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: Continuous Integration
 
 on:
@@ -9,7 +10,7 @@ on:
 permissions:
   contents: read
 
-.matrix: &matrix
+.matrix:
   pkg:
     - name: Example
       repo: https://github.com/JuliaLang/Example.jl
@@ -90,9 +91,9 @@ jobs:
 
   test-concept:
     name: Test ${{ matrix.pkg.name }} / Julia ${{ matrix.version }} (${{ matrix.os }}, ${{ matrix.arch }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        <<: *matrix
+    runs-on: ubuntu-latest
+    # strategy:
+    #   matrix:
+    #     <<: *matrix
     steps:
       - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,33 @@ on:
 permissions:
   contents: read
 
+.matrix: &matrix
+  pkg:
+    - name: Example
+      repo: https://github.com/JuliaLang/Example.jl
+  version:
+    - "1.6"
+    - "1"
+  os:
+    - ubuntu-latest
+    - macos-latest-large
+    - macos-latest-xlarge  # Apple silicon: https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+  arch:
+    - x86
+    - x64
+    - aarch64
+  exclude:
+    - os: ubuntu-latest
+      arch: aarch64
+    - os: macos-latest-large
+      arch: x86
+    - os: macos-latest-large
+      arch: aarch64
+    - os: macos-latest-xlarge
+      arch: x86
+    - os: macos-latest-xlarge
+      arch: x64
+
 jobs:
   test-typescript:
     name: TypeScript Tests
@@ -60,3 +87,12 @@ jobs:
       - name: Print Output
         id: output
         run: echo "${{ steps.test-action.outputs.time }}"
+
+  test-concept:
+    name: Test ${{ matrix.pkg.name }} / Julia ${{ matrix.version }} (${{ matrix.os }}, ${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        <<: *matrix
+    steps:
+      - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,32 +10,7 @@ on:
 permissions:
   contents: read
 
-.matrix:
-  pkg:
-    - name: Example
-      repo: https://github.com/JuliaLang/Example.jl
-  version:
-    - "1.6"
-    - "1"
-  os:
-    - ubuntu-latest
-    - macos-latest-large
-    - macos-latest-xlarge  # Apple silicon: https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
-  arch:
-    - x86
-    - x64
-    - aarch64
-  exclude:
-    - os: ubuntu-latest
-      arch: aarch64
-    - os: macos-latest-large
-      arch: x86
-    - os: macos-latest-large
-      arch: aarch64
-    - os: macos-latest-xlarge
-      arch: x86
-    - os: macos-latest-xlarge
-      arch: x64
+
 
 jobs:
   test-typescript:
@@ -97,3 +72,31 @@ jobs:
     #     <<: *matrix
     steps:
       - run: exit 0
+
+---
+.matrix:
+  pkg:
+    - name: Example
+      repo: https://github.com/JuliaLang/Example.jl
+  version:
+    - "1.6"
+    - "1"
+  os:
+    - ubuntu-latest
+    - macos-latest-large
+    - macos-latest-xlarge  # Apple silicon: https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+  arch:
+    - x86
+    - x64
+    - aarch64
+  exclude:
+    - os: ubuntu-latest
+      arch: aarch64
+    - os: macos-latest-large
+      arch: x86
+    - os: macos-latest-large
+      arch: aarch64
+    - os: macos-latest-xlarge
+      arch: x86
+    - os: macos-latest-xlarge
+      arch: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,29 @@
+matrix:
+  pkg:
+    - name: Example
+      repo: https://github.com/JuliaLang/Example.jl
+  version:
+    - "1.6"
+    - "1"
+  os:
+    - ubuntu-latest
+    - macos-latest-large
+    - macos-latest-xlarge  # Apple silicon: https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+  arch:
+    - x86
+    - x64
+    - aarch64
+  exclude:
+    - os: ubuntu-latest
+      arch: aarch64
+    - os: macos-latest-large
+      arch: x86
+    - os: macos-latest-large
+      arch: aarch64
+    - os: macos-latest-xlarge
+      arch: x86
+    - os: macos-latest-xlarge
+      arch: x64
 ---
 name: Continuous Integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: read
         run: |
-          echo "json=$(yq -o=json <.github/matrix/concept.yaml | jq -c)" | tee -a "$GITHUB_OUTPUT"
+          echo "json=$(yq eval .matrix -o=json <.github/matrix/concept.yaml | jq -c)" | tee -a "$GITHUB_OUTPUT"
 
   test-concept:
     name: Test ${{ matrix.pkg.name }} / Julia ${{ matrix.version }} (${{ matrix.os }}, ${{ matrix.arch }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,39 +64,24 @@ jobs:
         id: output
         run: echo "${{ steps.test-action.outputs.time }}"
 
+  test-concept-gen-matrix:
+    permissions:
+      contents: read  # Required to use `actions/checkout`
+      pull-requests: read
+    outputs:
+      json: ${{ steps.read.outputs.json }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: |
+          echo "json=$(yq -o=json <.github/matrix/concept.yaml | jq -c)" | tee -a "$GITHUB_OUTPUT"
+
   test-concept:
     name: Test ${{ matrix.pkg.name }} / Julia ${{ matrix.version }} (${{ matrix.os }}, ${{ matrix.arch }})
+    needs: test-concept-gen-matrix
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     <<: *matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.test-concept-gen-matrix.outputs.json) }}
     steps:
       - run: exit 0
-
----
-.matrix:
-  pkg:
-    - name: Example
-      repo: https://github.com/JuliaLang/Example.jl
-  version:
-    - "1.6"
-    - "1"
-  os:
-    - ubuntu-latest
-    - macos-latest-large
-    - macos-latest-xlarge  # Apple silicon: https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
-  arch:
-    - x86
-    - x64
-    - aarch64
-  exclude:
-    - os: ubuntu-latest
-      arch: aarch64
-    - os: macos-latest-large
-      arch: x86
-    - os: macos-latest-large
-      arch: aarch64
-    - os: macos-latest-xlarge
-      arch: x86
-    - os: macos-latest-xlarge
-      arch: x64


### PR DESCRIPTION
Testing out some concepts. Mainly what I want to do is have this action work as a filter for a GitHub action matrix. Specifically what I'm thinking of is having Julia version aliases like `MIN` (earliest version of Julia supported by this package) and versions like `1` where it is possible that once resolved they would run the same version of Julia. Ideally, we could skip these redundant jobs. If we resolve these version ranges into actual version numbers (e.g. `1.9.0`) the job matrix will only run one of these jobs. This alone doesn't require the matrix filtering I'm experimenting with but when considering a monorepo where `MIN` could resolve to several different versions for each different Julia package we may end up replacing the special `MIN` version with [`include`](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations)s